### PR TITLE
test(tts): 修复音频文件落盘测试

### DIFF
--- a/backend/src/services/tts/ttsManager.ts
+++ b/backend/src/services/tts/ttsManager.ts
@@ -27,7 +27,10 @@ export class TtsManager {
     this.cacheDriver = options.cacheDriver ?? new InMemoryTtsCache();
     this.metrics = options.metrics;
     const configuredOutputDir = options.audioOutputDir || process.env.TTS_AUDIO_OUTPUT_DIR;
-    this.audioOutputDir = path.resolve(process.cwd(), configuredOutputDir || 'storage/tts');
+    // 若已提供绝对路径则直接使用，否则相对于 cwd 解析
+    this.audioOutputDir = configuredOutputDir && path.isAbsolute(configuredOutputDir)
+      ? configuredOutputDir
+      : path.resolve(process.cwd(), configuredOutputDir || 'storage/tts');
     this.audioBaseUrl = this.normalizeBaseUrl(options.audioBaseUrl || process.env.TTS_AUDIO_BASE_URL || 'http://localhost:5001/static/tts');
     this.audioDownloadTimeoutMs = options.audioDownloadTimeoutMs ?? parseInt(process.env.TTS_AUDIO_DOWNLOAD_TIMEOUT_MS || '20000', 10);
 


### PR DESCRIPTION
## 问题概述

TTS 路由测试中的音频文件存在性检查失败，原因是测试配置的输出目录与实际写入目录不一致。

## 问题根因

1. **时序问题**: 测试在导入路由**之后**才设置 `TTS_AUDIO_OUTPUT_DIR` 环境变量
2. **构造时初始化**: `TtsManager` 在构造函数中立即读取环境变量并创建目录
3. **路径不一致**: 导致测试断言检查的目录 ≠ 实际音频写入的目录

## 修复方案

### 1. TtsManager 支持绝对路径 (`ttsManager.ts:31-33`)
```typescript
// 若已提供绝对路径则直接使用，否则相对于 cwd 解析
this.audioOutputDir = configuredOutputDir && path.isAbsolute(configuredOutputDir)
  ? configuredOutputDir
  : path.resolve(process.cwd(), configuredOutputDir || 'storage/tts');
```

### 2. 测试环境变量前置 (`tts.test.ts`)
- ✅ 在文件顶部设置所有 TTS 环境变量
- ✅ 在导入业务代码**之前**完成配置  
- ✅ 使用 `os.tmpdir() + PID` 创建进程隔离的测试目录

## 验证结果

```bash
✅ TTS API Routes (2/2 通过)
  ✓ POST /api/tts 应该生成 Mock 音频 (164ms)
  ✓ POST /api/tts 缺少文本时返回 400
```

- 音频文件正确写入测试临时目录
- 测试后自动清理临时文件
- 不影响生产逻辑和其他测试

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)